### PR TITLE
Initialize GAMECONTROLLER in EmuWindow_SDL2 (#6078)

### DIFF
--- a/src/citra/emu_window/emu_window_sdl2.cpp
+++ b/src/citra/emu_window/emu_window_sdl2.cpp
@@ -134,7 +134,7 @@ void EmuWindow_SDL2::Fullscreen() {
 
 EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
     // Initialize the window
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_GAMECONTROLLER) < 0) {
         LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
         exit(1);
     }


### PR DESCRIPTION
Resolves #6077

If only `SDL_INIT_JOYSTICK` is used, `InputCommon::SDL::SDLState` later tries to initialize the game controller in a background thread, which on macOS causes a crash in `SDL_PumpEvents`. From [the SDL docs](https://wiki.libsdl.org/SDL_Init), `SDL_INIT_GAMECONTROLLER` implies `SDL_INIT_JOYSTICK`, so this should be a total superset of the previous behavior.